### PR TITLE
docs: add back-navigation link to cpp-linter hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # clang-tools Python distribution
 
 [![Release Python Wheels](https://github.com/cpp-linter/clang-tools-wheel/actions/workflows/release.yml/badge.svg)](https://github.com/cpp-linter/clang-tools-wheel/actions/workflows/release.yml)
+[![cpp-linter hub](https://img.shields.io/badge/%F0%9F%8F%A0_cpp--linter_hub-%E2%86%90_home-22863a)](https://cpp-linter.github.io/)
 
 This project provides pip-installable Python wheels for `clang-format` and `clang-tidy`.
 


### PR DESCRIPTION
Adds `← Back to cpp-linter hub` link near the top of the README for easier cross-project navigation.